### PR TITLE
Updated license and copyright

### DIFF
--- a/Feed the Monster/README.md
+++ b/Feed the Monster/README.md
@@ -1,5 +1,23 @@
 # FeedTheMonster
 
+## License
+All the source code included in this repo is licensed under a [BSD 2-Clause license](../LICENSE):
 
+```
+Copyright (c) 2016, Apps Factory
+All rights reserved.
 
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
 
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+```
+
+All digital content included in this repository is released under a [Creative Commons Attribution License](https://creativecommons.org/licenses/by/4.0/legalcode) (CC-BY).
+
+Copyright (c) 2016 Originally developed by a consortium led by [Apps Factory](http://www.appsfactory.ro/), subsequent translations by [Curious Learning](https://www.curiouslearning.org/).


### PR DESCRIPTION
Propagating the following changes, to update the licensing and copyright notices for Feed the Monster:

* Norad-Eduapp4syria/Norad-Eduapp4syria#5
* Norad-Eduapp4syria/Norad-Eduapp4syria#6
